### PR TITLE
Add an optional parameter to the swaps endpoint to only show incoming or outgoing swaps

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -15,6 +15,7 @@ pub fn get_swaps(
   page: Option<i64>,
   pool: Option<&String>,
   address: Option<&String>,
+  is_incoming: Option<&bool>,
 ) -> Result<PaginatedResult<models::Swap>, diesel::result::Error> {
   // It is common when using Diesel with Actix web to import schema-related
   // modules inside a function's scope (rather than the normal module's scope)
@@ -29,6 +30,10 @@ pub fn get_swaps(
 
   if let Some(address) = address {
     query = query.filter(initiator_address.eq(address));
+  }
+
+  if let Some(is_incoming) = is_incoming {
+    query = query.filter(is_sending_zil.eq(is_incoming))
   }
 
   Ok(query

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,13 @@ struct AddressInfo {
 }
 
 #[derive(Deserialize)]
+struct SwapInfo {
+  pool: Option<String>,
+  address: Option<String>,
+  is_incoming: Option<bool>,
+}
+
+#[derive(Deserialize)]
 struct TimeInfo {
   timestamp: Option<i64>,
 }
@@ -70,13 +77,13 @@ async fn hello() -> impl Responder {
 #[get("/swaps")]
 async fn get_swaps(
     query: web::Query<PaginationInfo>,
-    filter: web::Query<AddressInfo>,
+    filter: web::Query<SwapInfo>,
     pool: web::Data<DbPool>,
 ) -> Result<HttpResponse, Error> {
     let conn = pool.get().expect("couldn't get db connection from pool");
 
     // use web::block to offload blocking Diesel code without blocking server thread
-    let swaps = web::block(move || db::get_swaps(&conn, query.per_page, query.page, filter.pool.as_ref(), filter.address.as_ref()))
+    let swaps = web::block(move || db::get_swaps(&conn, query.per_page, query.page, filter.pool.as_ref(), filter.address.as_ref(), filter.is_incoming.as_ref()))
         .await
         .map_err(|e| {
             eprintln!("{}", e);


### PR DESCRIPTION
This PR adds an `is_incoming` parameter to the /swaps endpoint to only show swaps going in or out. This is needed to be able to create an orderbook with equal depth on both sides.