### PR TITLE
Multi distributor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ reqwest = { version = "^0.10.9", features = ["blocking", "json"] }
 bech32 = "0.7.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_yaml = "0.8.17"
 uuid = { version = "^0.6.5", features = ["serde"] }
 
 [[bin]]

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,0 +1,62 @@
+---
+mainnet:
+  zilswap_address_hex: "0xBa11eB7bCc0a02e947ACF03Cc651Bfaf19C9EC00"
+  start_txn_hash:
+    mint: "0x00a0e4800c709f38d97cd7e769c756a8c059e6aca5eaeace81509c8ab7eccdf4"
+    burn: "0x9f53e01877d7b40db95d332c3172e1f0d628fd68eabc1e7fcf3316be5619fd50"
+    swap: "0xee5c4cc44822ee48d2ea8466a4a03c9adb41635caac600e27700fc5e81d8d2dc"
+  distributions:
+    - name: "ZWAP Rewards"
+      reward_token: zwap
+      distributor_name: Zilswap
+      distributor_address_hex: ""
+      developer_address: zil1zjvc2m9f5vh8zl57su5j8lflgaq2lx08kcwdvy
+      emission_info:
+        epoch_period: 604800 # 1 week
+        tokens_per_epoch: 6250_000_000_000_000
+        tokens_for_retroactive_distribution: 50000_000_000_000_000
+        retroactive_distribution_cutoff_time: 1610964000
+        distribution_start_time: 1612339200
+        total_number_of_epochs: 152
+        initial_epoch_number: 2
+        developer_token_ratio_bps: 1500
+        trader_token_ratio_bps: 2000
+      incentived_pools:
+        zil1p5suryq6q647usxczale29cu3336hhp376c627: 65 # ZWAP
+        zil14pzuzq6v6pmmmrfjhczywguu0e97djepxt8g3e: 7  # gZIL
+        zil1zu72vac254htqpg3mtywdcfm84l3dfd9qzww8t: 7  # XSGD
+        zil18f5rlhqz9vndw4w8p60d0n7vg3n9sqvta7n6t2: 4  # PORT
+        zil1s8xzysqcxva2x6aducncv9um3zxr36way3fx9g: 4  # ZCH
+        zil1h63h5rlg7avatnlzhfnfzwn8vfspwkapzdy2aw: 4  # XCAD
+        zil1lq3ghn3yaqk0w7fqtszv53hejunpyfyh3rx9gc: 3  # Elons
+        zil14jmjrkvfcz2uvj3y69kl6gas34ecuf2j5ggmye: 1  # RED
+        zil1r9dcsrya4ynuxnzaznu00e6hh3kpt7vhvzgva0: 1  # ZLF
+        zil1ucvrn22x8366vzpw5t7su6eyml2auczu6wnqqg: 1  # ZYRO
+        zil1w5hwupgc9rxyuyd742g2c9annwahugrx80fw9h: 1  # GARY
+        zil1504065pp76uuxm7s9m2c4gwszhez8pu3mp6r8c: 1  # STREAM
+testnet:
+  zilswap_address_hex: "0x1a62dd9c84b0c8948cb51fc664ba143e7a34985c"
+  start_txn_hash:
+    mint: "0x9b8b5695c406d71137f5f420a67cf6b352ae865068530d293116dde072dbfdf6"
+    burn: "0xfbec07771a8cabd7c90c084b4ca77bf0a7216970eae5f68233b21cf13c947a3f"
+    swap: "0x1b660c073e30157e50085848c3595fda62c87ce1e7db328a46f8eb48c4c36957"
+  distributions:
+    - name: "ZWAP Rewards"
+      reward_token: zwap
+      distributor_name: Zilswap
+      distributor_address_hex: ""
+      developer_address: zil1ua2dhnlykmxtnuaudmqd3uju6altn6lq0lqvl9
+      emission_info:
+        epoch_period: 604800 # 1 week
+        tokens_per_epoch: 6250_000_000_000_000
+        tokens_for_retroactive_distribution: 50000_000_000_000_000
+        retroactive_distribution_cutoff_time: 1610964000
+        distribution_start_time: 1612339200
+        total_number_of_epochs: 152
+        initial_epoch_number: 2
+        developer_token_ratio_bps: 1500
+        trader_token_ratio_bps: 2000
+      incentived_pools:
+        zil1fytuayks6njpze00ukasq3m4y4s44k79hvz8q5: 3 # gZIL
+        zil10a9z324aunx2qj64984vke93gjdnzlnl5exygv: 2 # XSGD
+        zil1ktmx2udqc77eqq0mdjn8kqdvwjf9q5zvy6x7vu: 5 # ZWAP

--- a/config/config.yml
+++ b/config/config.yml
@@ -18,18 +18,16 @@ mainnet:
         developer_token_ratio_bps: 1500
         trader_token_ratio_bps: 2000
       incentived_pools:
-        zil1p5suryq6q647usxczale29cu3336hhp376c627: 65 # ZWAP
+        zil1p5suryq6q647usxczale29cu3336hhp376c627: 70 # ZWAP
         zil14pzuzq6v6pmmmrfjhczywguu0e97djepxt8g3e: 7  # gZIL
         zil1zu72vac254htqpg3mtywdcfm84l3dfd9qzww8t: 7  # XSGD
         zil18f5rlhqz9vndw4w8p60d0n7vg3n9sqvta7n6t2: 4  # PORT
-        zil1s8xzysqcxva2x6aducncv9um3zxr36way3fx9g: 4  # ZCH
-        zil1h63h5rlg7avatnlzhfnfzwn8vfspwkapzdy2aw: 4  # XCAD
+        zil1504065pp76uuxm7s9m2c4gwszhez8pu3mp6r8c: 4  # STREAM
         zil1lq3ghn3yaqk0w7fqtszv53hejunpyfyh3rx9gc: 3  # Elons
         zil14jmjrkvfcz2uvj3y69kl6gas34ecuf2j5ggmye: 1  # RED
-        zil1r9dcsrya4ynuxnzaznu00e6hh3kpt7vhvzgva0: 1  # ZLF
         zil1ucvrn22x8366vzpw5t7su6eyml2auczu6wnqqg: 1  # ZYRO
         zil1w5hwupgc9rxyuyd742g2c9annwahugrx80fw9h: 1  # GARY
-        zil1504065pp76uuxm7s9m2c4gwszhez8pu3mp6r8c: 1  # STREAM
+        zil1qldr63ds7yuspqcf02263y2lctmtqmr039vrht: 1  # PAINT
 testnet:
   zilswap_address_hex: "0x1a62dd9c84b0c8948cb51fc664ba143e7a34985c"
   distributions:

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,15 +1,11 @@
 ---
 mainnet:
   zilswap_address_hex: "0xBa11eB7bCc0a02e947ACF03Cc651Bfaf19C9EC00"
-  start_txn_hash:
-    mint: "0x00a0e4800c709f38d97cd7e769c756a8c059e6aca5eaeace81509c8ab7eccdf4"
-    burn: "0x9f53e01877d7b40db95d332c3172e1f0d628fd68eabc1e7fcf3316be5619fd50"
-    swap: "0xee5c4cc44822ee48d2ea8466a4a03c9adb41635caac600e27700fc5e81d8d2dc"
   distributions:
     - name: "ZWAP Rewards"
       reward_token: zwap
       distributor_name: Zilswap
-      distributor_address_hex: ""
+      distributor_address_hex: "0xca6d3f56218aaa89cd20406cf22aee26ba8f6089"
       developer_address: zil1zjvc2m9f5vh8zl57su5j8lflgaq2lx08kcwdvy
       emission_info:
         epoch_period: 604800 # 1 week
@@ -36,10 +32,6 @@ mainnet:
         zil1504065pp76uuxm7s9m2c4gwszhez8pu3mp6r8c: 1  # STREAM
 testnet:
   zilswap_address_hex: "0x1a62dd9c84b0c8948cb51fc664ba143e7a34985c"
-  start_txn_hash:
-    mint: "0x9b8b5695c406d71137f5f420a67cf6b352ae865068530d293116dde072dbfdf6"
-    burn: "0xfbec07771a8cabd7c90c084b4ca77bf0a7216970eae5f68233b21cf13c947a3f"
-    swap: "0x1b660c073e30157e50085848c3595fda62c87ce1e7db328a46f8eb48c4c36957"
   distributions:
     - name: "ZWAP Rewards"
       reward_token: zwap

--- a/migrations/2021-07-29-032006_create_claims/down.sql
+++ b/migrations/2021-07-29-032006_create_claims/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE claims

--- a/migrations/2021-07-29-032006_create_claims/up.sql
+++ b/migrations/2021-07-29-032006_create_claims/up.sql
@@ -1,0 +1,14 @@
+-- Your SQL goes here
+CREATE TABLE claims (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  transaction_hash VARCHAR NOT NULL,
+  event_sequence INTEGER NOT NULL,
+  block_height INTEGER NOT NULL,
+  block_timestamp TIMESTAMP NOT NULL,
+  distributor_address VARCHAR NOT NULL,
+  epoch_number INTEGER NOT NULL,
+  initiator_address VARCHAR NOT NULL
+);
+
+CREATE INDEX index_initiator_address_on_claim ON claims (initiator_address);
+CREATE UNIQUE INDEX index_unique_claim ON claims (distributor_address, epoch_number, initiator_address);

--- a/migrations/2021-07-29-032006_create_claims/up.sql
+++ b/migrations/2021-07-29-032006_create_claims/up.sql
@@ -10,5 +10,4 @@ CREATE TABLE claims (
   initiator_address VARCHAR NOT NULL
 );
 
-CREATE INDEX index_initiator_address_on_claim ON claims (initiator_address);
-CREATE UNIQUE INDEX index_unique_claim ON claims (distributor_address, epoch_number, initiator_address);
+CREATE UNIQUE INDEX index_unique_claim ON claims (initiator_address, distributor_address, epoch_number);

--- a/migrations/2021-07-29-034409_create_backfill_completions/down.sql
+++ b/migrations/2021-07-29-034409_create_backfill_completions/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE backfill_completions

--- a/migrations/2021-07-29-034409_create_backfill_completions/up.sql
+++ b/migrations/2021-07-29-034409_create_backfill_completions/up.sql
@@ -1,0 +1,8 @@
+-- Your SQL goes here-- Your SQL goes here
+CREATE TABLE backfill_completions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  contract_address VARCHAR NOT NULL,
+  event_name VARCHAR NOT NULL
+);
+
+CREATE UNIQUE INDEX index_address_event_on_backfill_completions ON backfill_completions (contract_address, event_name);

--- a/migrations/2021-08-05-070734_add_distributor_address_to_distributions/down.sql
+++ b/migrations/2021-08-05-070734_add_distributor_address_to_distributions/down.sql
@@ -1,0 +1,9 @@
+-- This file should undo anything in `up.sql`
+-- Your SQL goes here
+ALTER TABLE distributions
+REMOVE COLUMN distributor_address;
+
+CREATE INDEX index_epoch_number_on_distr ON distributions (epoch_number);
+CREATE UNIQUE INDEX index_epoch_address_on_distr ON distributions (epoch_number, address_hex);
+
+DROP INDEX index_unique_on_distr;

--- a/migrations/2021-08-05-070734_add_distributor_address_to_distributions/up.sql
+++ b/migrations/2021-08-05-070734_add_distributor_address_to_distributions/up.sql
@@ -1,0 +1,11 @@
+-- Your SQL goes here
+ALTER TABLE distributions
+ADD COLUMN distributor_address VARCHAR NOT NULL DEFAULT '0xca6d3f56218aaa89cd20406cf22aee26ba8f6089';
+
+ALTER TABLE distributions
+ALTER COLUMN distributor_address DROP DEFAULT;
+
+CREATE UNIQUE INDEX index_unique_on_distr ON distributions (distributor_address, epoch_number, address_hex);
+
+DROP INDEX index_epoch_number_on_distr;
+DROP INDEX index_epoch_address_on_distr;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,14 +1,6 @@
 use std::{fmt};
-use std::collections::HashMap;
 
-pub mod zwap_emission {
-  pub static RETROACTIVE_DISTRIBUTION_CUTOFF_TIME: i64 = 1610964000;
-  pub static DISTRIBUTION_START_TIME: i64 = 1612339200;
-  pub static EPOCH_PERIOD: i64 = 604800; // one week
-  pub static TOTAL_NUMBER_OF_EPOCH: u32 = 152 + 1; // +1 for dummy epoch released for retroactive traders airdrop
-  pub static TOKENS_PER_EPOCH: u32 = 6250;
-}
-
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum Event {
   Minted,
   Burnt,
@@ -29,67 +21,6 @@ impl fmt::Display for Event {
 pub enum Network {
   MainNet,
   TestNet,
-}
-
-impl Network {
-  pub fn first_txn_hash_for(&self, event: &Event) -> &str {
-    match *self {
-      Network::MainNet => {
-        match event {
-          Event::Minted => "0x00a0e4800c709f38d97cd7e769c756a8c059e6aca5eaeace81509c8ab7eccdf4",
-          Event::Burnt => "0x9f53e01877d7b40db95d332c3172e1f0d628fd68eabc1e7fcf3316be5619fd50",
-          Event::Swapped => "0xee5c4cc44822ee48d2ea8466a4a03c9adb41635caac600e27700fc5e81d8d2dc",
-        }
-      },
-      Network::TestNet => {
-        match event {
-          Event::Minted => "0x9b8b5695c406d71137f5f420a67cf6b352ae865068530d293116dde072dbfdf6",
-          Event::Burnt => "0xfbec07771a8cabd7c90c084b4ca77bf0a7216970eae5f68233b21cf13c947a3f",
-          Event::Swapped => "0x1b660c073e30157e50085848c3595fda62c87ce1e7db328a46f8eb48c4c36957",
-        }
-      },
-    }
-  }
-
-  pub fn contract_hash(&self) -> String {
-    String::from(match *self {
-      Network::TestNet => "0x1a62dd9c84b0c8948cb51fc664ba143e7a34985c",
-      Network::MainNet => "0xBa11eB7bCc0a02e947ACF03Cc651Bfaf19C9EC00",
-    })
-  }
-
-  pub fn incentived_pools(&self) -> HashMap<String, u32> {
-    match *self {
-      Network::TestNet => [
-        (String::from("zil1fytuayks6njpze00ukasq3m4y4s44k79hvz8q5"), 3), // gZIL
-        (String::from("zil10a9z324aunx2qj64984vke93gjdnzlnl5exygv"), 2), // XSGD
-        (String::from("zil1ktmx2udqc77eqq0mdjn8kqdvwjf9q5zvy6x7vu"), 5), // ZWAP
-      ].iter().cloned().collect(),
-      Network::MainNet => [
-        (String::from("zil1p5suryq6q647usxczale29cu3336hhp376c627"), 65), // ZWAP
-        (String::from("zil14pzuzq6v6pmmmrfjhczywguu0e97djepxt8g3e"), 7), // gZIL
-        (String::from("zil1zu72vac254htqpg3mtywdcfm84l3dfd9qzww8t"), 7), // XSGD
-
-        (String::from("zil18f5rlhqz9vndw4w8p60d0n7vg3n9sqvta7n6t2"), 4), // PORT
-        (String::from("zil1s8xzysqcxva2x6aducncv9um3zxr36way3fx9g"), 4), // ZCH
-        (String::from("zil1h63h5rlg7avatnlzhfnfzwn8vfspwkapzdy2aw"), 4), // XCAD
-        (String::from("zil1lq3ghn3yaqk0w7fqtszv53hejunpyfyh3rx9gc"), 4), // Elons
-
-        (String::from("zil14jmjrkvfcz2uvj3y69kl6gas34ecuf2j5ggmye"), 1), // REDC
-        (String::from("zil1r9dcsrya4ynuxnzaznu00e6hh3kpt7vhvzgva0"), 1), // ZLF
-        (String::from("zil1ucvrn22x8366vzpw5t7su6eyml2auczu6wnqqg"), 1), // ZYRO
-        (String::from("zil1w5hwupgc9rxyuyd742g2c9annwahugrx80fw9h"), 1), // GARY
-        (String::from("zil1504065pp76uuxm7s9m2c4gwszhez8pu3mp6r8c"), 1), // STREAM
-      ].iter().cloned().collect(),
-    }
-  }
-
-  pub fn developer_address(&self) -> String {
-    String::from(match *self {
-      Network::TestNet => "zil1ua2dhnlykmxtnuaudmqd3uju6altn6lq0lqvl9",
-      Network::MainNet => "zil1zjvc2m9f5vh8zl57su5j8lflgaq2lx08kcwdvy",
-    })
-  }
 }
 
 impl fmt::Display for Network {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,10 +1,11 @@
 use std::{fmt};
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Event {
   Minted,
   Burnt,
   Swapped,
+  Claimed,
 }
 
 impl fmt::Display for Event {
@@ -13,6 +14,7 @@ impl fmt::Display for Event {
       Event::Minted => write!(f, "Mint"),
       Event::Burnt => write!(f, "Burnt"),
       Event::Swapped => write!(f, "Swapped"),
+      Event::Claimed => write!(f, "Claimed"),
     }
   }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -74,6 +74,7 @@ pub fn get_liquidity_changes(
 /// Get distributions by epoch, optionally filtered by address.
 pub fn get_distributions(
   conn: &PgConnection,
+  distr_address: Option<&str>,
   epoch: Option<i32>,
   address: Option<&str>,
 ) -> Result<Vec<models::Distribution>, diesel::result::Error> {
@@ -87,6 +88,10 @@ pub fn get_distributions(
 
   if let Some(address) = address {
     query = query.filter(address_bech32.eq(address));
+  }
+
+  if let Some(distr_address) = distr_address {
+    query = query.filter(distributor_address.eq(distr_address));
   }
 
   Ok(query
@@ -107,6 +112,28 @@ pub fn get_distributions_by_address(
     .filter(address_bech32.eq(address));
 
   Ok(query.load(conn)?)
+}
+
+/// Get unclaimed distributions for an address.
+pub fn get_unclaimed_distributions_by_address(
+  conn: &PgConnection,
+  address: &str,
+) -> Result<Vec<models::Distribution>, diesel::result::Error> {
+  let sql = "
+    SELECT d.id, d.distributor_address, d.epoch_number,
+    d.address_bech32, d.address_hex, d.amount, d.proof
+    FROM distributions d
+    LEFT OUTER JOIN claims c
+    ON d.distributor_address = c.distributor_address
+    AND d.epoch_number = c.epoch_number
+    WHERE address_bech32 = $1
+    AND c.id IS NULL
+  ";
+
+  let query = diesel::sql_query(sql)
+    .bind::<Text, _>(address);
+
+  Ok(query.load::<models::Distribution>(conn)?)
 }
 
 /// Get all pools.

--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -64,7 +64,7 @@ impl Validate for EmissionConfig {
   }
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct DistributionConfig {
   name: String,
   reward_token: String,

--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -1,105 +1,217 @@
-
 use bech32::{decode, FromBase32};
-use bigdecimal::{BigDecimal};
+use bigdecimal::{BigDecimal, Zero};
 use hex::{encode};
 use ring::{digest};
-use serde::{Serialize};
+use serde::{Serialize, Deserialize};
 use std::collections::HashMap;
+use std::convert::{TryInto};
 use std::time::{SystemTime};
+use std::str::{FromStr};
 use trees::{Tree, TreeWalk, Node, walk::Visit};
 
-use crate::constants::{zwap_emission};
+#[derive(Debug, Clone)]
+pub struct InvalidConfigError {
+  details: String
+}
+
+pub trait Validate {
+  fn validate(&self) -> Result<(), InvalidConfigError>;
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct EmissionConfig {
+  epoch_period: i64,
+  tokens_per_epoch: String,
+  tokens_for_retroactive_distribution: String,
+  retroactive_distribution_cutoff_time: i64,
+  distribution_start_time: i64,
+  total_number_of_epochs: u32,
+  initial_epoch_number: u32,
+  developer_token_ratio_bps: u16,
+  trader_token_ratio_bps: u16,
+}
+
+impl Validate for EmissionConfig {
+  fn validate(&self) -> Result<(), InvalidConfigError> {
+    let mut errs = vec![];
+    if self.retroactive_distribution_cutoff_time > 0 && self.initial_epoch_number < 1 {
+      errs.push("initial_epoch_number must be more than 0")
+    }
+    if self.total_number_of_epochs == 0 {
+      errs.push("total_number_of_epochs must be more than 0")
+    }
+    match BigDecimal::from_str(self.tokens_for_retroactive_distribution.as_str()) {
+      Ok(r) => {
+        if self.retroactive_distribution_cutoff_time > 0 && r.is_zero() {
+          errs.push("tokens_for_retroactive_distribution must be more than 0")
+        }
+      }
+      Err(_) => errs.push("tokens_for_retroactive_distribution is invalid")
+    }
+    match BigDecimal::from_str(self.tokens_per_epoch.as_str()) {
+      Ok(r) => {
+        if r.is_zero() {
+          errs.push("tokens_per_epoch must be more than 0")
+        }
+      }
+      Err(_) => errs.push("tokens_per_epoch is invalid")
+    }
+    if errs.len() > 0 {
+      Err(InvalidConfigError{details: errs.join("\n")})
+    } else {
+      Ok(())
+    }
+  }
+}
+
+#[derive(Deserialize, Clone)]
+pub struct DistributionConfig {
+  name: String,
+  reward_token: String,
+  distributor_name: String,
+  distributor_address_hex: String,
+  developer_address: String,
+  emission_info: EmissionConfig,
+  incentived_pools: HashMap<String, u32>,
+}
+
+impl DistributionConfig {
+  pub fn emission(&self) -> EmissionConfig {
+    self.emission_info.clone()
+  }
+
+  pub fn developer_address(&self) -> String {
+    self.developer_address.clone()
+  }
+
+  pub fn incentived_pools(&self) -> HashMap<String, u32> {
+    self.incentived_pools.clone()
+  }
+}
+
+pub type DistributionConfigs = Vec<DistributionConfig>;
+impl Validate for DistributionConfigs {
+  fn validate(&self) -> Result<(), InvalidConfigError> {
+    if self.len() == 0 {
+      return Err(InvalidConfigError{details: "No distributions found".to_owned()})
+    }
+    for d in self {
+      if let Err(e) = d.emission_info.validate() {
+        return Err(InvalidConfigError{details: format!("Distribution for '{}' is invalid: {:?}", d.name, e)})
+      }
+    }
+    Ok(())
+  }
+}
 
 #[derive(Serialize)]
 pub struct EpochInfo {
-  epoch_period: i64,
-  tokens_per_epoch: u32,
+  emission_info: EmissionConfig,
+  retroactive_distribution_epoch_number: Option<u32>,
+  first_epoch_number: u32,
   first_epoch_start: i64,
-  next_epoch_start: i64,
-  total_epoch: u32,
-  current_epoch: i64,
+  last_epoch_number: u32,
+  current_epoch_number: u32,
+  current_epoch_start: Option<i64>,
+  current_epoch_end: Option<i64>,
+  tokens_for_epoch: BigDecimal,
+  next_epoch_start: Option<i64>,
 }
 
 impl EpochInfo {
-  pub fn new(epoch_number: i64) -> EpochInfo {
-    let first_epoch_start = zwap_emission::DISTRIBUTION_START_TIME;
-    let epoch_period = zwap_emission::EPOCH_PERIOD;
-    let total_epoch = zwap_emission::TOTAL_NUMBER_OF_EPOCH;
-    let tokens_per_epoch = zwap_emission::TOKENS_PER_EPOCH;
+  pub fn new(emission: EmissionConfig, epoch_number: Option<u32>) -> EpochInfo {
+    let current_epoch_number = match epoch_number {
+      Some(n) => n,
+      None => {
+        let current_time = SystemTime::now()
+          .duration_since(SystemTime::UNIX_EPOCH)
+          .expect("invalid server time")
+          .as_secs() as i64;
+        let epochs_after_start = (current_time - emission.distribution_start_time) as f64 / emission.epoch_period as f64;
+        std::cmp::max(0, epochs_after_start.ceil() as u32 + emission.initial_epoch_number - 1)
+      }
+    };
 
-    let next_epoch_start =
-      if epoch_number == 0 || epoch_number == 1 {
-        first_epoch_start
+    let retroactive_distribution_epoch_number =
+      if emission.retroactive_distribution_cutoff_time > 0 {
+        Some(emission.initial_epoch_number - 1)
       } else {
-        // first real epoch starts from 2
-        std::cmp::min(epoch_number - 1, total_epoch.into()) * epoch_period + first_epoch_start
+        None
       };
 
-    EpochInfo {
-      epoch_period,
-      tokens_per_epoch,
+    let first_epoch_number = emission.initial_epoch_number;
+    let last_epoch_number = emission.total_number_of_epochs + emission.initial_epoch_number - 1;
+
+    let first_epoch_start = emission.distribution_start_time;
+
+    let (current_epoch_start, current_epoch_end) =
+      if current_epoch_number < emission.initial_epoch_number {
+        (Some(0), Some(emission.retroactive_distribution_cutoff_time))
+      } else if current_epoch_number <= last_epoch_number {
+        let start = i64::from(current_epoch_number - emission.initial_epoch_number) * emission.epoch_period + first_epoch_start;
+        (Some(start), Some(start + emission.epoch_period))
+      } else {
+        (None, None)
+      };
+
+    let next_epoch_start =
+      if current_epoch_number < emission.initial_epoch_number {
+        Some(first_epoch_start)
+      } else if current_epoch_number < last_epoch_number {
+        current_epoch_end
+      } else {
+        None
+      };
+
+    let tokens_for_epoch =
+      if current_epoch_number < emission.initial_epoch_number {
+        BigDecimal::from_str(emission.tokens_for_retroactive_distribution.as_str()).unwrap()
+      } else if current_epoch_number <= last_epoch_number {
+        BigDecimal::from_str(emission.tokens_per_epoch.as_str()).unwrap()
+      } else {
+        BigDecimal::from(0)
+      };
+
+    Self {
+      emission_info: emission,
+      retroactive_distribution_epoch_number,
+      first_epoch_number,
       first_epoch_start,
+      last_epoch_number,
+      current_epoch_number,
+      current_epoch_start,
+      current_epoch_end,
+      tokens_for_epoch,
       next_epoch_start,
-      total_epoch,
-      current_epoch: epoch_number,
     }
-  }
-
-  pub fn default() -> EpochInfo {
-    let current_time = SystemTime::now()
-      .duration_since(SystemTime::UNIX_EPOCH)
-      .expect("invalid server time")
-      .as_secs() as i64;
-
-    let epoch_number = (current_time - zwap_emission::DISTRIBUTION_START_TIME) as f64 / zwap_emission::EPOCH_PERIOD as f64;
-    let current_epoch = std::cmp::max(0, epoch_number.ceil() as i64 + 1); // first real epoch starts from 2
-
-    EpochInfo::new(current_epoch)
   }
 
   pub fn is_initial(&self) -> bool {
-    self.current_epoch == 0 || self.current_epoch == 1
+    self.current_epoch_number < self.first_epoch_number
   }
 
-  // XXX: epoch 1 is an empty epoch that only has trader data
-  pub fn trader_epoch(&self) -> bool {
-    self.current_epoch == 1
+  pub fn epoch_number(&self) -> i32 {
+    self.current_epoch_number.try_into().unwrap()
   }
 
-  pub fn epoch_number(&self) -> i64 {
-    self.current_epoch
+  pub fn current_epoch_start(&self) -> Option<i64> {
+    self.current_epoch_start
   }
 
-  pub fn current_epoch_start(&self) -> i64 {
-    if self.is_initial() {
-      0
-    } else {
-      (std::cmp::min(self.current_epoch - 1, zwap_emission::TOTAL_NUMBER_OF_EPOCH.into()) - 1) * zwap_emission::EPOCH_PERIOD + zwap_emission::DISTRIBUTION_START_TIME
-    }
+  pub fn current_epoch_end(&self) -> Option<i64> {
+    self.current_epoch_end
   }
 
-  pub fn current_epoch_end(&self) -> i64 {
-    if self.is_initial() {
-      zwap_emission::RETROACTIVE_DISTRIBUTION_CUTOFF_TIME
-    } else {
-      self.next_epoch_start()
-    }
-  }
-
-  pub fn next_epoch_start(&self) -> i64 {
-    self.next_epoch_start
+  pub fn distribution_ended(&self) -> bool {
+    self.current_epoch_number > self.last_epoch_number
   }
 
   pub fn tokens_for_epoch(&self) -> BigDecimal {
-    if self.is_initial() {
-      BigDecimal::from(50_000)* BigDecimal::from(10u64.pow(12))
-    } else {
-      BigDecimal::from(self.tokens_per_epoch)* BigDecimal::from(10u64.pow(12))
-    }
+    self.tokens_for_epoch.clone()
   }
 
   pub fn tokens_for_developers(&self) -> BigDecimal {
-    self.tokens_for_epoch() * BigDecimal::from(15) / BigDecimal::from(100)
+    self.tokens_for_epoch() * BigDecimal::from(self.emission_info.developer_token_ratio_bps) / BigDecimal::from(10000)
   }
 
   pub fn tokens_for_users(&self) -> BigDecimal {
@@ -108,7 +220,7 @@ impl EpochInfo {
 
   pub fn tokens_for_traders(&self) -> BigDecimal {
     if self.is_initial() {
-      self.tokens_for_users() * BigDecimal::from(20) / BigDecimal::from(100)
+      self.tokens_for_users() * BigDecimal::from(self.emission_info.trader_token_ratio_bps) / BigDecimal::from(10000)
     } else {
       BigDecimal::default()
     }

--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -64,7 +64,7 @@ impl Validate for EmissionConfig {
   }
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct DistributionConfig {
   name: String,
   reward_token: String,
@@ -80,8 +80,12 @@ impl DistributionConfig {
     self.emission_info.clone()
   }
 
-  pub fn developer_address(&self) -> String {
-    self.developer_address.clone()
+  pub fn developer_address(&self) -> &str {
+    self.developer_address.as_str()
+  }
+
+  pub fn distributor_address(&self) -> &str {
+    self.distributor_address_hex.as_str()
   }
 
   pub fn incentived_pools(&self) -> HashMap<String, u32> {
@@ -233,8 +237,9 @@ impl EpochInfo {
 
 #[derive(Serialize, Clone)]
 pub struct Distribution {
-  address_human: String,
   address: Vec::<u8>,
+  address_hex: String,
+  address_human: String,
   amount: BigDecimal,
   hash: Vec::<u8>,
 }
@@ -244,7 +249,8 @@ impl Distribution {
     let (_hrp, data) = decode(address.as_str()).expect("Could not decode bech32 string!");
     let bytes = Vec::<u8>::from_base32(&data).unwrap();
     let hash = hash(&bytes, &amount);
-    Distribution{address_human: address, address: bytes, amount, hash}
+    let hex = encode(&bytes);
+    Distribution{address_human: address, address_hex: hex, address: bytes, amount, hash}
   }
 
   pub fn from(map: HashMap<String, BigDecimal>) -> Vec<Distribution> {
@@ -256,16 +262,16 @@ impl Distribution {
     arr
   }
 
-  pub fn address(&self) -> String {
-    self.address_human.clone()
+  pub fn address_bech32(&self) -> &str {
+    self.address_human.as_str()
   }
 
-  pub fn address_bytes(&self) -> Vec<u8> {
-    self.address.clone()
+  pub fn address_hex(&self) -> &str {
+    self.address_hex.as_str()
   }
 
-  pub fn amount(&self) -> BigDecimal {
-    self.amount.clone()
+  pub fn amount(&self) -> &BigDecimal {
+    &self.amount
   }
 
   pub fn hash(&self) -> Vec::<u8> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,7 +193,7 @@ async fn get_weighted_liquidity(
   Ok(HttpResponse::Ok().json(liquidity))
 }
 
-/// Generate data for the all ended epochs and save it to db.
+/// Generate distribution data and save it to db.
 // steps:
 // get pools (filtered for the ones to award - epoch 0 all, epoch 1 only xsgd & gzil)
 // for each pool:
@@ -201,15 +201,16 @@ async fn get_weighted_liquidity(
 // 2. get time weighted liquidity from start_time to end_time for each address that has liquidity at start_time
 // split reward by pool and time weighted liquidity
 // if epoch 0, get swap_volume and split additional reward by volume
-#[get("epoch/generate")]
+#[get("epoch/generate/{id}")]
 async fn generate_epoch(
   pool: web::Data<DbPool>,
   distr_config: web::Data<DistributionConfigs>,
+  web::Path(id): web::Path<usize>,
 ) -> Result<HttpResponse, Error> {
   let conn = pool.get().expect("couldn't get db connection from pool");
-  let distr = distr_config[0].clone();
 
   let result = web::block(move || {
+    let distr = distr_config[id].clone();
     let current_epoch = EpochInfo::new(distr.emission(), None);
     let current_epoch_number = current_epoch.epoch_number();
     let epoch_number = std::cmp::max(0, current_epoch_number - 1);
@@ -296,7 +297,7 @@ async fn generate_epoch(
     // add developer share
     let dt = epoch_info.tokens_for_developers();
     if dt.is_positive() {
-      let current = accumulator.entry(distr_config[0].developer_address().to_owned()).or_insert(BigDecimal::default());
+      let current = accumulator.entry(distr.developer_address().to_owned()).or_insert(BigDecimal::default());
       *current += dt
     }
 
@@ -310,6 +311,7 @@ async fn generate_epoch(
     let proofs = distribution::get_proofs(tree.clone());
     let records: Vec<models::NewDistribution> = proofs.iter().map(|(d, p)| {
       models::NewDistribution{
+        distributor_address: distr.distributor_address(),
         epoch_number: &epoch_number,
         address_bech32: d.address_bech32(),
         address_hex: d.address_hex(),
@@ -359,66 +361,71 @@ async fn get_distribution_amounts(
   web::Path(user_address): web::Path<String>,
 ) -> Result<HttpResponse, Error> {
   let conn = pool.get().expect("couldn't get db connection from pool");
-  let distr = distr_config[0].clone();
-
-  let epoch_info = EpochInfo::new(distr.emission(), None);
-  let start = epoch_info.current_epoch_start();
-  let end = epoch_info.current_epoch_end();
 
   let result = web::block(move || {
-    let mut accumulator: HashMap<String, BigDecimal> = HashMap::new();
+    let mut r: HashMap<String, HashMap<String, BigDecimal>> = HashMap::new();
 
-    // get pool TWAL and individual TWAL
-    struct PoolDistribution {
-      tokens: BigDecimal,
-      weighted_liquidity: BigDecimal,
-    }
-    let pt = epoch_info.tokens_for_liquidity_providers();
-    let distribution: HashMap<String, PoolDistribution> =
-      if epoch_info.is_initial() {
-        let total_liquidity: BigDecimal = db::get_time_weighted_liquidity(&conn, start, end, None)?.into_iter().map(|i| i.amount).sum();
-        db::get_pools(&conn)?.into_iter().map(|pool| {
-          (pool,
-            PoolDistribution{ // share distribution fully
-              tokens: utils::round_down(pt.clone(), 0),
-              weighted_liquidity: total_liquidity.clone(),
-            }
-          )
-        }).collect()
-      } else {
-        let pool_weights = distr.incentived_pools();
-        let total_weight: u32 = pool_weights.values().into_iter().sum();
-        db::get_time_weighted_liquidity(&conn, start, end, None)?.into_iter().filter_map(|i| {
-          if let Some(weight) = pool_weights.get(&i.pool) {
-            Some((i.pool,
-              PoolDistribution{ // each pool has a weighted allocation
-                tokens: utils::round_down(pt.clone() * BigDecimal::from(*weight) / BigDecimal::from(total_weight), 0),
-                weighted_liquidity: i.amount,
-              }
-            ))
-          } else {
-            None
-          }
-        }).collect()
-      };
+    for distr in distr_config.iter() {
+      let mut accumulator: HashMap<String, BigDecimal> = HashMap::new();
 
-    // for each individual TWAL, calculate the tokens
-    let user_liquidity = db::get_time_weighted_liquidity(&conn, start, end, Some(&user_address))?;
-    for l in user_liquidity.into_iter() {
-      if let Some(pool) = distribution.get(&l.pool) {
-        let share = utils::round_down(l.amount * pool.tokens.clone() / pool.weighted_liquidity.clone(), 0);
-        let current = accumulator.entry(l.pool).or_insert(BigDecimal::default());
-        *current += share
+      let epoch_info = EpochInfo::new(distr.emission(), None);
+      let start = epoch_info.current_epoch_start();
+      let end = epoch_info.current_epoch_end();
+
+      // get pool TWAL and individual TWAL
+      struct PoolDistribution {
+        tokens: BigDecimal,
+        weighted_liquidity: BigDecimal,
       }
+      let pt = epoch_info.tokens_for_liquidity_providers();
+      let distribution: HashMap<String, PoolDistribution> =
+        if epoch_info.is_initial() {
+          let total_liquidity: BigDecimal = db::get_time_weighted_liquidity(&conn, start, end, None)?.into_iter().map(|i| i.amount).sum();
+          db::get_pools(&conn)?.into_iter().map(|pool| {
+            (pool,
+              PoolDistribution{ // share distribution fully
+                tokens: utils::round_down(pt.clone(), 0),
+                weighted_liquidity: total_liquidity.clone(),
+              }
+            )
+          }).collect()
+        } else {
+          let pool_weights = distr.incentived_pools();
+          let total_weight: u32 = pool_weights.values().into_iter().sum();
+          db::get_time_weighted_liquidity(&conn, start, end, None)?.into_iter().filter_map(|i| {
+            if let Some(weight) = pool_weights.get(&i.pool) {
+              Some((i.pool,
+                PoolDistribution{ // each pool has a weighted allocation
+                  tokens: utils::round_down(pt.clone() * BigDecimal::from(*weight) / BigDecimal::from(total_weight), 0),
+                  weighted_liquidity: i.amount,
+                }
+              ))
+            } else {
+              None
+            }
+          }).collect()
+        };
+
+      // for each individual TWAL, calculate the tokens
+      let user_liquidity = db::get_time_weighted_liquidity(&conn, start, end, Some(&user_address))?;
+      for l in user_liquidity.into_iter() {
+        if let Some(pool) = distribution.get(&l.pool) {
+          let share = utils::round_down(l.amount * pool.tokens.clone() / pool.weighted_liquidity.clone(), 0);
+          let current = accumulator.entry(l.pool).or_insert(BigDecimal::default());
+          *current += share
+        }
+      }
+
+      // add developer share
+      if distr.developer_address() == user_address {
+        let current = accumulator.entry("developer".to_string()).or_insert(BigDecimal::default());
+        *current += epoch_info.tokens_for_developers()
+      }
+
+      r.insert(distr.distributor_address().to_string(), accumulator);
     }
 
-    // add developer share
-    if distr.developer_address() == user_address {
-      let current = accumulator.entry("developer".to_string()).or_insert(BigDecimal::default());
-      *current += epoch_info.tokens_for_developers()
-    }
-
-    Ok::<HashMap<String, BigDecimal>, diesel::result::Error>(accumulator)
+    Ok::<HashMap<String, HashMap<String, BigDecimal>>, diesel::result::Error>(r)
   }).await
     .map_err(|e| {
       eprintln!("{}", e);
@@ -433,11 +440,12 @@ async fn get_distribution_amounts(
 async fn get_distribution_data(
   pool: web::Data<DbPool>,
   filter: web::Query<AddressInfo>,
+  web::Path(distributor_address): web::Path<String>,
   web::Path(epoch_number): web::Path<i32>,
 ) -> Result<HttpResponse, Error> {
   let conn = pool.get().expect("couldn't get db connection from pool");
 
-  let distributions = web::block(move || db::get_distributions(&conn, Some(epoch_number), filter.address.as_deref()))
+  let distributions = web::block(move || db::get_distributions(&conn, Some(&distributor_address), Some(epoch_number), filter.address.as_deref()))
       .await
       .map_err(|e| {
           eprintln!("{}", e);
@@ -455,7 +463,7 @@ async fn get_distribution_data_by_address(
 ) -> Result<HttpResponse, Error> {
   let conn = pool.get().expect("couldn't get db connection from pool");
 
-  let distributions = web::block(move || db::get_distributions_by_address(&conn, &user_address))
+  let distributions = web::block(move || db::get_unclaimed_distributions_by_address(&conn, &user_address))
       .await
       .map_err(|e| {
           eprintln!("{}", e);

--- a/src/models.rs
+++ b/src/models.rs
@@ -126,9 +126,11 @@ pub struct PoolTx {
   pub change_amount: Option<BigDecimal>,
 }
 
-#[derive(Debug, Identifiable, Queryable, Serialize)]
+#[derive(Debug, Identifiable, Queryable, QueryableByName, Serialize)]
+#[table_name="distributions"]
 pub struct Distribution {
   pub id: Uuid,
+  pub distributor_address: String,
   pub epoch_number: i32,
   pub address_bech32: String,
   pub address_hex: String,
@@ -139,6 +141,7 @@ pub struct Distribution {
 #[derive(Debug, Clone, Insertable)]
 #[table_name="distributions"]
 pub struct NewDistribution<'a> {
+  pub distributor_address: &'a str,
   pub epoch_number: &'a i32,
   pub address_bech32: &'a str,
   pub address_hex: &'a str,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,4 +1,25 @@
 table! {
+    backfill_completions (id) {
+        id -> Uuid,
+        contract_address -> Varchar,
+        event_name -> Varchar,
+    }
+}
+
+table! {
+    claims (id) {
+        id -> Uuid,
+        transaction_hash -> Varchar,
+        event_sequence -> Int4,
+        block_height -> Int4,
+        block_timestamp -> Timestamp,
+        distributor_address -> Varchar,
+        epoch_number -> Int4,
+        initiator_address -> Varchar,
+    }
+}
+
+table! {
     distributions (id) {
         id -> Uuid,
         epoch_number -> Int4,
@@ -39,32 +60,34 @@ table! {
     }
 }
 
-table! {
-    pool_txs (id) {
-        id -> Uuid,
-        transaction_hash -> Varchar,
-        block_height -> Int4,
-        block_timestamp -> Timestamp,
-        initiator_address -> Varchar,
-        token_address -> Varchar,
+ table! {
+      pool_txs (id) {
+          id -> Uuid,
+          transaction_hash -> Varchar,
+          block_height -> Int4,
+          block_timestamp -> Timestamp,
+          initiator_address -> Varchar,
+          token_address -> Varchar,
 
-        token_amount -> Nullable<Numeric>,
-        zil_amount -> Nullable<Numeric>,
+          token_amount -> Nullable<Numeric>,
+          zil_amount -> Nullable<Numeric>,
 
-        tx_type -> Varchar,
+          tx_type -> Varchar,
 
-        swap0_is_sending_zil -> Nullable<Bool>,
+          swap0_is_sending_zil -> Nullable<Bool>,
 
-        swap1_token_address -> Nullable<Varchar>,
-        swap1_token_amount -> Nullable<Numeric>,
-        swap1_zil_amount -> Nullable<Numeric>,
-        swap1_is_sending_zil -> Nullable<Bool>,
+          swap1_token_address -> Nullable<Varchar>,
+          swap1_token_amount -> Nullable<Numeric>,
+          swap1_zil_amount -> Nullable<Numeric>,
+          swap1_is_sending_zil -> Nullable<Bool>,
 
-        change_amount -> Nullable<Numeric>,
-    }
-}
+          change_amount -> Nullable<Numeric>,
+      }
+  }
 
 allow_tables_to_appear_in_same_query!(
+    backfill_completions,
+    claims,
     distributions,
     liquidity_changes,
     swaps,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -22,6 +22,7 @@ table! {
 table! {
     distributions (id) {
         id -> Uuid,
+        distributor_address -> Varchar,
         epoch_number -> Int4,
         address_bech32 -> Varchar,
         address_hex -> Varchar,
@@ -60,30 +61,30 @@ table! {
     }
 }
 
- table! {
-      pool_txs (id) {
-          id -> Uuid,
-          transaction_hash -> Varchar,
-          block_height -> Int4,
-          block_timestamp -> Timestamp,
-          initiator_address -> Varchar,
-          token_address -> Varchar,
+table! {
+    pool_txs (id) {
+        id -> Uuid,
+        transaction_hash -> Varchar,
+        block_height -> Int4,
+        block_timestamp -> Timestamp,
+        initiator_address -> Varchar,
+        token_address -> Varchar,
 
-          token_amount -> Nullable<Numeric>,
-          zil_amount -> Nullable<Numeric>,
+        token_amount -> Nullable<Numeric>,
+        zil_amount -> Nullable<Numeric>,
 
-          tx_type -> Varchar,
+        tx_type -> Varchar,
 
-          swap0_is_sending_zil -> Nullable<Bool>,
+        swap0_is_sending_zil -> Nullable<Bool>,
 
-          swap1_token_address -> Nullable<Varchar>,
-          swap1_token_amount -> Nullable<Numeric>,
-          swap1_zil_amount -> Nullable<Numeric>,
-          swap1_is_sending_zil -> Nullable<Bool>,
+        swap1_token_address -> Nullable<Varchar>,
+        swap1_token_amount -> Nullable<Numeric>,
+        swap1_zil_amount -> Nullable<Numeric>,
+        swap1_is_sending_zil -> Nullable<Bool>,
 
-          change_amount -> Nullable<Numeric>,
-      }
-  }
+        change_amount -> Nullable<Numeric>,
+    }
+}
 
 allow_tables_to_appear_in_same_query!(
     backfill_completions,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -7,7 +7,6 @@ use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::Url;
 use std::time::{Duration};
 use std::convert::TryInto;
-use std::collections::HashMap;
 use std::ops::Neg;
 use std::str::FromStr;
 
@@ -20,21 +19,15 @@ use crate::constants::{Event, Network};
 pub struct WorkerConfig {
   network: Network,
   contract_hash: String,
-  initial_txn_hashes: HashMap<Event, String>,
+  distributor_contract_hashes: Vec<String>,
 }
 
 impl WorkerConfig {
-  pub fn from_value(value: &serde_yaml::Value, network: Network) -> Self {
-    let hashes = &value["start_txn_hash"];
-    let f = serde_yaml::from_value::<String>;
+  pub fn new(network: Network, contract_hash: &str, distributor_contract_hashes: Vec<&str>) -> Self {
     Self {
       network: network.clone(),
-      contract_hash: f(value["zilswap_address_hex"].clone()).expect("invalid zilswap_address_hex"),
-      initial_txn_hashes: [
-        (Event::Minted,  f(hashes["mint"].clone()).expect("invalid initial mint tx hash")),
-        (Event::Burnt,   f(hashes["burn"].clone()).expect("invalid initial burn tx hash")),
-        (Event::Swapped, f(hashes["swap"].clone()).expect("invalid initial swap tx hash")),
-      ].iter().cloned().collect(),
+      contract_hash: contract_hash.to_owned(),
+      distributor_contract_hashes: distributor_contract_hashes.into_iter().map(|h| h.to_owned()).collect(),
     }
   }
 }
@@ -57,12 +50,16 @@ impl Actor for Coordinator {
   fn started(&mut self, ctx: &mut Self::Context) {
     println!("Coordinator is alive!");
     let config = self.config.clone();
-    let pool = self.db_pool.clone();
-    let coordinator = ctx.address();
-    let arbiter = SyncArbiter::start(3, move || EventFetchActor::new(config.clone(), pool.clone(), coordinator.clone()));
-    arbiter.do_send(FetchMints { page_number: 1 });
-    arbiter.do_send(FetchBurns { page_number: 1 });
-    arbiter.do_send(FetchSwaps { page_number: 1 });
+    let db_pool = self.db_pool.clone();
+    let address = ctx.address();
+    let arbiter = SyncArbiter::start(3, move || EventFetchActor::new(config.clone(), db_pool.clone(), address.clone()));
+    let contract_hash = self.config.contract_hash.as_str();
+    arbiter.do_send(Fetch::new(contract_hash, Event::Minted));
+    arbiter.do_send(Fetch::new(contract_hash, Event::Burnt));
+    arbiter.do_send(Fetch::new(contract_hash, Event::Swapped));
+    for h in &self.config.distributor_contract_hashes {
+      arbiter.do_send(Fetch::new(h.as_str(), Event::Claimed));
+    }
     self.arbiter = Some(arbiter);
   }
 
@@ -80,12 +77,7 @@ impl Handler<NextFetch> for Coordinator {
   fn handle(&mut self, msg: NextFetch, ctx: &mut Context<Self>) -> Self::Result {
     ctx.run_later(Duration::from_secs(msg.delay), move |worker, _| {
       let arbiter = worker.arbiter.as_ref().unwrap();
-      let page_number = msg.page_number;
-      match msg.event{
-        Event::Minted => arbiter.do_send(FetchMints { page_number }),
-        Event::Burnt => arbiter.do_send(FetchBurns { page_number }),
-        Event::Swapped => arbiter.do_send(FetchSwaps { page_number }),
-      };
+      arbiter.do_send(msg.get_next());
     });
   }
 }
@@ -98,28 +90,59 @@ impl Handler<NextFetch> for Coordinator {
 #[derive(Message)]
 #[rtype(result = "()")]
 struct NextFetch {
-  event: Event,
-  page_number: u16,
+  msg: Fetch,
   delay: u64,
 }
 
+impl NextFetch {
+  fn poll(msg: &Fetch) -> Self {
+    Self {
+      msg: Fetch {
+        contract_hash: msg.contract_hash.clone(),
+        event: msg.event.clone(),
+        page_number: 1,
+      },
+      delay: 60,
+    }
+  }
+
+  fn paginate(msg: &Fetch) -> Self {
+    Self {
+      msg: Fetch {
+        contract_hash: msg.contract_hash.clone(),
+        event: msg.event.clone(),
+        page_number:  msg.page_number + 1,
+      },
+      delay: 1,
+    }
+  }
+
+  fn retry(msg: &Fetch) -> Self {
+    Self { msg: msg.clone(), delay: 10 }
+  }
+
+  fn get_next(&self) -> Fetch {
+    self.msg.clone()
+  }
+}
+
 // Messages for fetch actors
-#[derive(Message)]
+#[derive(Message, Clone)]
 #[rtype(result = "()")]
-struct FetchSwaps {
+struct Fetch {
+  contract_hash: String,
+  event: Event,
   page_number: u16,
 }
 
-#[derive(Message)]
-#[rtype(result = "()")]
-struct FetchMints {
-  page_number: u16,
-}
-
-#[derive(Message)]
-#[rtype(result = "()")]
-struct FetchBurns {
-  page_number: u16,
+impl Fetch {
+  fn new(contract_hash: &str, event: Event) -> Self {
+    Self {
+      contract_hash: contract_hash.to_owned(),
+      event,
+      page_number: 1,
+    }
+  }
 }
 
 /// The actual fetch result
@@ -152,6 +175,8 @@ impl From<diesel::result::Error> for FetchError {
   }
 }
 
+type PersistResult = Result<(), diesel::result::Error>;
+
 /// Define fetch actor
 struct EventFetchActor {
   config: WorkerConfig,
@@ -182,13 +207,13 @@ impl EventFetchActor {
     }
   }
 
-  fn get_and_parse(&mut self, page_number: u16, event: Event) -> Result<responses::ViewBlockResponse, FetchError> {
-    println!("Fetching {} page {}", event, page_number);
+  fn get_and_parse(&mut self, contract_hash: &str, event: Event, page_number: u16) -> Result<responses::ViewBlockResponse, FetchError> {
+    println!("Fetching {} for {} page {}", event, contract_hash, page_number);
 
     let url = Url::parse_with_params(
       format!(
         "https://api.viewblock.io/v1/zilliqa/contracts/{}/events/{}",
-        self.config.contract_hash,
+        contract_hash,
         event
       )
       .as_str(),
@@ -201,19 +226,11 @@ impl EventFetchActor {
     let resp = self.client.get(url).send()?;
     let body = resp.text()?;
 
-    println!("Parsing {} page {}", event, page_number);
+    println!("Parsing {} for {} page {}", event, contract_hash, page_number);
     // println!("{}", body);
     let result: responses::ViewBlockResponse = serde_json::from_str(body.as_str())?;
-    return Ok(result)
-  }
 
-  fn backfill_complete_for(&self, event: Event) -> bool {
-    let hash = String::from(self.config.initial_txn_hashes.get(&event).expect("unknown event"));
-    let conn = self.db_pool.get().expect("couldn't get db connection from pool");
-    match event {
-      Event::Minted | Event::Burnt => db::liquidity_change_exists(&conn, hash).unwrap(),
-      Event::Swapped => db::swap_exists(&conn, hash).unwrap(),
-    }
+    return Ok(result)
   }
 }
 
@@ -226,236 +243,186 @@ impl Actor for EventFetchActor {
 }
 
 /// Define handler for `FetchMints` message
-impl Handler<FetchMints> for EventFetchActor {
+impl Handler<Fetch> for EventFetchActor {
   type Result = ();
 
-  fn handle(&mut self, msg: FetchMints, _ctx: &mut SyncContext<Self>) -> Self::Result {
+  fn handle(&mut self, msg: Fetch, _ctx: &mut SyncContext<Self>) -> Self::Result {
+    let (contract_hash, event) = (msg.contract_hash.as_str(), msg.event.clone());
     let mut execute = || -> FetchResult {
-      let result = self.get_and_parse(msg.page_number, Event::Minted)?;
+      let result = self.get_and_parse(contract_hash, event, msg.page_number)?;
+      let conn = self.db_pool.get().expect("couldn't get db connection from pool");
 
       if result.txs.len() == 0 {
-        println!("Done with mints.");
-        return Ok(NextFetch{event: Event::Minted, page_number: 1, delay: 60 });
+        println!("Done with {} events.", event);
+        db::insert_backfill_completion(models::NewBackfillCompletion { contract_address: contract_hash, event_name: event.to_string().as_str() }, &conn)?;
+        return Ok(NextFetch::poll(&msg));
       }
 
       for tx in result.txs {
-        for (i, event) in tx.events.iter().enumerate() {
-          let name = event.name.as_str();
-          if name == "Mint" {
-            let address = event.params.get("address").unwrap().as_str().expect("Malformed response!");
-            let pool = event.params.get("pool").unwrap().as_str().expect("Malformed response!");
-            let amount = event.params.get("amount").unwrap().as_str().expect("Malformed response!");
-
-            let transfer_event = tx.events.iter().find(|&event| event.name.as_str() == "TransferFromSuccess").unwrap();
-            let token_amount = transfer_event.params.get("amount").unwrap().as_str().expect("Malformed response!");
-            let zil_amount = tx.value.as_str();
-
-            let add_liquidity = models::NewLiquidityChange {
-              transaction_hash: &tx.hash,
-              event_sequence: &(i as i32),
-              block_height: &tx.block_height,
-              block_timestamp: &chrono::NaiveDateTime::from_timestamp(tx.timestamp / 1000, (tx.timestamp % 1000).try_into().unwrap()),
-              initiator_address: address,
-              token_address: pool,
-              change_amount: &BigDecimal::from_str(amount).unwrap(),
-              token_amount: &BigDecimal::from_str(token_amount).unwrap(),
-              zil_amount: &BigDecimal::from_str(zil_amount).unwrap(),
-            };
-
-            println!("Inserting: {:?}", add_liquidity);
-
-            let conn = self.db_pool.get().expect("couldn't get db connection from pool");
-            let res = db::insert_liquidity_change(add_liquidity, &conn);
-            if let Err(e) = res {
-              if self.backfill_complete_for(Event::Minted) {
-                println!("Fetched till last inserted mint.");
-                return Ok(NextFetch{event: Event::Minted, page_number: 1, delay: 60 });
-              }
-              match e {
-                diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::UniqueViolation, _) => println!("Ignoring duplicate entry!"),
-                _ => return Err(FetchError::from(e))
-              }
+        for (i, ev) in tx.events.iter().enumerate() {
+          let persist = match event {
+            Event::Minted => persist_mint_event,
+            Event::Burnt => persist_burn_event,
+            Event::Swapped => persist_swap_event,
+            Event::Claimed => persist_claim_event,
+          };
+          if let Err(err) = persist(&conn, &tx, &ev, &i.try_into().unwrap()) {
+            if db::backfill_completed(&conn, contract_hash, event.to_string().as_str())? {
+              println!("Fetched till last inserted {} event.", event);
+              return Ok(NextFetch::poll(&msg));
+            }
+            match err {
+              diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::UniqueViolation, _) => println!("Ignoring duplicate entry!"),
+              _ => return Err(FetchError::from(err))
             }
           }
         }
       }
 
       println!("Next page..");
-      return Ok(NextFetch{event: Event::Minted, page_number: msg.page_number + 1, delay: 1 });
+      return Ok(NextFetch::paginate(&msg));
     };
 
     // handle retrying
     let result = execute();
     match result {
-      Ok(msg) => self.coordinator.do_send(msg),
+      Ok(next_msg) => self.coordinator.do_send(next_msg),
       Err(e) => {
         println!("{:#?}", e);
         println!("Unhandled error while fetching, retrying in 10 seconds..");
-        self.coordinator.do_send(NextFetch{event: Event::Minted, page_number: msg.page_number, delay: 10 });
+        self.coordinator.do_send(NextFetch::retry(&msg));
       }
     }
   }
 }
 
-/// Define handler for `FetchBurns` message
-impl Handler<FetchBurns> for EventFetchActor {
-  type Result = ();
-
-  fn handle(&mut self, msg: FetchBurns, _ctx: &mut SyncContext<Self>) -> Self::Result {
-    let mut execute = || -> FetchResult {
-      let result = self.get_and_parse(msg.page_number, Event::Burnt)?;
-
-      if result.txs.len() == 0 {
-        println!("Done with burns.");
-        return Ok(NextFetch{event: Event::Burnt, page_number: 1, delay: 60 });
-      }
-
-      for tx in result.txs {
-        for (i, event) in tx.events.iter().enumerate() {
-          let name = event.name.as_str();
-          if name == "Burnt" {
-
-            let address = event.params.get("address").unwrap().as_str().expect("Malformed response!");
-            let pool = event.params.get("pool").unwrap().as_str().expect("Malformed response!");
-            let amount = event.params.get("amount").unwrap().as_str().expect("Malformed response!");
-
-            let transfer_event = tx.events.iter().find(|&event| event.name.as_str() == "TransferSuccess").unwrap();
-            let token_amount = transfer_event.params.get("amount").unwrap().as_str().expect("Malformed response!");
-            let zil_amount = tx.internal_transfers[0].get("value").unwrap().as_str().expect("Malformed response!");
-
-            let remove_liquidity = models::NewLiquidityChange {
-              transaction_hash: &tx.hash,
-              event_sequence: &(i as i32),
-              block_height: &tx.block_height,
-              block_timestamp: &chrono::NaiveDateTime::from_timestamp(tx.timestamp / 1000, (tx.timestamp % 1000).try_into().unwrap()),
-              initiator_address: address,
-              token_address: pool,
-              change_amount: &BigDecimal::from_str(amount).unwrap().neg(),
-              token_amount: &BigDecimal::from_str(token_amount).unwrap(),
-              zil_amount: &BigDecimal::from_str(zil_amount).unwrap(),
-            };
-
-            println!("Inserting: {:?}", remove_liquidity);
-
-            let conn = self.db_pool.get().expect("couldn't get db connection from pool");
-            let res = db::insert_liquidity_change(remove_liquidity, &conn);
-            if let Err(e) = res {
-              if self.backfill_complete_for(Event::Burnt) {
-                println!("Fetched till last inserted burn.");
-                return Ok(NextFetch{event: Event::Burnt, page_number: 1, delay: 60 });
-              }
-              match e {
-                diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::UniqueViolation, _) => println!("Ignoring duplicate entry!"),
-                _ => return Err(FetchError::from(e))
-              }
-            }
-          }
-        }
-      }
-
-      println!("Next page..");
-      return Ok(NextFetch{event: Event::Burnt, page_number: msg.page_number + 1, delay: 1 });
-    };
-
-    // handle retrying
-    let result = execute();
-    match result {
-      Ok(m) => self.coordinator.do_send(m),
-      Err(e) => {
-        println!("{:#?}", e);
-        println!("Unhandled error while fetching, retrying in 10 seconds..");
-        self.coordinator.do_send(NextFetch{event: Event::Burnt, page_number: msg.page_number, delay: 10 });
-      }
-    }
+fn persist_mint_event(conn: &PgConnection, tx: &responses::ViewBlockTx, event: &responses::ViewBlockEvent, event_sequence: &i32) -> PersistResult {
+  let name = event.name.as_str();
+  if name != "Mint" {
+    return Ok(())
   }
+
+  let address = event.params.get("address").unwrap().as_str().expect("Malformed response!");
+  let pool = event.params.get("pool").unwrap().as_str().expect("Malformed response!");
+  let amount = event.params.get("amount").unwrap().as_str().expect("Malformed response!");
+
+  let transfer_event = tx.events.iter().find(|&event| event.name.as_str() == "TransferFromSuccess").unwrap();
+  let token_amount = transfer_event.params.get("amount").unwrap().as_str().expect("Malformed response!");
+  let zil_amount = tx.value.as_str();
+
+  let add_liquidity = models::NewLiquidityChange {
+    transaction_hash: &tx.hash,
+    event_sequence: &event_sequence,
+    block_height: &tx.block_height,
+    block_timestamp: &chrono::NaiveDateTime::from_timestamp(tx.timestamp / 1000, (tx.timestamp % 1000).try_into().unwrap()),
+    initiator_address: address,
+    token_address: pool,
+    change_amount: &BigDecimal::from_str(amount).unwrap(),
+    token_amount: &BigDecimal::from_str(token_amount).unwrap(),
+    zil_amount: &BigDecimal::from_str(zil_amount).unwrap(),
+  };
+
+  println!("Inserting: {:?}", add_liquidity);
+  db::insert_liquidity_change(add_liquidity, &conn)
 }
 
-/// Define handler for `FetchSwaps` message
-impl Handler<FetchSwaps> for EventFetchActor {
-  type Result = ();
+fn persist_burn_event(conn: &PgConnection, tx: &responses::ViewBlockTx, event: &responses::ViewBlockEvent, event_sequence: &i32) -> PersistResult {
+  let name = event.name.as_str();
+  if name != "Burnt" {
+    return Ok(())
+  }
+  let address = event.params.get("address").unwrap().as_str().expect("Malformed response!");
+  let pool = event.params.get("pool").unwrap().as_str().expect("Malformed response!");
+  let amount = event.params.get("amount").unwrap().as_str().expect("Malformed response!");
 
-  fn handle(&mut self, msg: FetchSwaps, _ctx: &mut SyncContext<Self>) -> Self::Result {
-    let mut execute = || -> FetchResult {
-      let result = self.get_and_parse(msg.page_number, Event::Swapped)?;
+  let transfer_event = tx.events.iter().find(|&event| event.name.as_str() == "TransferSuccess").unwrap();
+  let token_amount = transfer_event.params.get("amount").unwrap().as_str().expect("Malformed response!");
+  let zil_amount = tx.internal_transfers[0].get("value").unwrap().as_str().expect("Malformed response!");
 
-      if result.txs.len() == 0 {
-        println!("Done with swaps.");
-        return Ok(NextFetch{event: Event::Swapped, page_number: 1, delay: 60 });
-      }
+  let remove_liquidity = models::NewLiquidityChange {
+    transaction_hash: &tx.hash,
+    event_sequence: &event_sequence,
+    block_height: &tx.block_height,
+    block_timestamp: &chrono::NaiveDateTime::from_timestamp(tx.timestamp / 1000, (tx.timestamp % 1000).try_into().unwrap()),
+    initiator_address: address,
+    token_address: pool,
+    change_amount: &BigDecimal::from_str(amount).unwrap().neg(),
+    token_amount: &BigDecimal::from_str(token_amount).unwrap(),
+    zil_amount: &BigDecimal::from_str(zil_amount).unwrap(),
+  };
 
-      for tx in result.txs {
-        for (i, event) in tx.events.iter().enumerate() {
-          let name = event.name.as_str();
-          if name == "Swapped" {
-            let address = event.params.get("address").unwrap().as_str().expect("Malformed response!");
-            let pool = event.params.get("pool").unwrap().as_str().expect("Malformed response!");
-            let input_amount = event.params.pointer("/input/0/params/0").unwrap().as_str().expect("Malformed response!");
-            let output_amount = event.params.pointer("/output/0/params/0").unwrap().as_str().expect("Malformed response!");
-            let input_name = event.params.pointer("/input/1/name").unwrap().as_str().expect("Malformed response!");
-            let input_denom = input_name.split(".").last().expect("Malformed response!");
+  println!("Inserting: {:?}", remove_liquidity);
+  db::insert_liquidity_change(remove_liquidity, &conn)
+}
 
-            let token_amount;
-            let zil_amount;
-            let is_sending_zil;
-            match input_denom {
-              "Token" => {
-                token_amount = BigDecimal::from_str(input_amount).unwrap();
-                zil_amount = BigDecimal::from_str(output_amount).unwrap();
-                is_sending_zil = false;
-              },
-              "Zil" => {
-                zil_amount = BigDecimal::from_str(input_amount).unwrap();
-                token_amount = BigDecimal::from_str(output_amount).unwrap();
-                is_sending_zil = true;
-              }
-              _ => {
-                panic!("Malformed input denom!");
-              }
-            }
+fn persist_swap_event(conn: &PgConnection, tx: &responses::ViewBlockTx, event: &responses::ViewBlockEvent, event_sequence: &i32) -> PersistResult {
+  let name = event.name.as_str();
+  if name != "Swapped" {
+    return Ok(())
+  }
 
-            let new_swap = models::NewSwap {
-              transaction_hash: &tx.hash,
-              event_sequence: &(i as i32),
-              block_height: &tx.block_height,
-              block_timestamp: &chrono::NaiveDateTime::from_timestamp(tx.timestamp / 1000, (tx.timestamp % 1000).try_into().unwrap()),
-              initiator_address: address,
-              token_address: pool,
-              token_amount: &token_amount,
-              zil_amount: &zil_amount,
-              is_sending_zil: &is_sending_zil,
-            };
+  let address = event.params.get("address").unwrap().as_str().expect("Malformed response!");
+  let pool = event.params.get("pool").unwrap().as_str().expect("Malformed response!");
+  let input_amount = event.params.pointer("/input/0/params/0").unwrap().as_str().expect("Malformed response!");
+  let output_amount = event.params.pointer("/output/0/params/0").unwrap().as_str().expect("Malformed response!");
+  let input_name = event.params.pointer("/input/1/name").unwrap().as_str().expect("Malformed response!");
+  let input_denom = input_name.split(".").last().expect("Malformed response!");
 
-            println!("Inserting: {:?}", new_swap);
-
-            let conn = self.db_pool.get().expect("couldn't get db connection from pool");
-            let res = db::insert_swap(new_swap, &conn);
-            if let Err(e) = res {
-              if self.backfill_complete_for(Event::Swapped) {
-                println!("Fetched till last inserted swap.");
-                return Ok(NextFetch{event: Event::Swapped, page_number: 1, delay: 60 });
-              }
-              match e {
-                diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::UniqueViolation, _) => println!("Ignoring duplicate entry!"),
-                _ => return Err(FetchError::from(e))
-              }
-            }
-          }
-        }
-      }
-
-      println!("Next page..");
-      return Ok(NextFetch{event: Event::Swapped, page_number: msg.page_number + 1, delay: 1 });
-    };
-
-    // handle retrying
-    let result = execute();
-    match result {
-      Ok(msg) => self.coordinator.do_send(msg),
-      Err(e) => {
-        println!("{:#?}", e);
-        println!("Unhandled error while fetching, retrying in 10 seconds..");
-        self.coordinator.do_send(NextFetch{event: Event::Swapped, page_number: msg.page_number, delay: 10 });
-      }
+  let token_amount;
+  let zil_amount;
+  let is_sending_zil;
+  match input_denom {
+    "Token" => {
+      token_amount = BigDecimal::from_str(input_amount).unwrap();
+      zil_amount = BigDecimal::from_str(output_amount).unwrap();
+      is_sending_zil = false;
+    },
+    "Zil" => {
+      zil_amount = BigDecimal::from_str(input_amount).unwrap();
+      token_amount = BigDecimal::from_str(output_amount).unwrap();
+      is_sending_zil = true;
+    }
+    _ => {
+      panic!("Malformed input denom!");
     }
   }
+
+  let new_swap = models::NewSwap {
+    transaction_hash: &tx.hash,
+    event_sequence: &event_sequence,
+    block_height: &tx.block_height,
+    block_timestamp: &chrono::NaiveDateTime::from_timestamp(tx.timestamp / 1000, (tx.timestamp % 1000).try_into().unwrap()),
+    initiator_address: address,
+    token_address: pool,
+    token_amount: &token_amount,
+    zil_amount: &zil_amount,
+    is_sending_zil: &is_sending_zil,
+  };
+
+  println!("Inserting: {:?}", new_swap);
+  db::insert_swap(new_swap, &conn)
+}
+
+fn persist_claim_event(conn: &PgConnection, tx: &responses::ViewBlockTx, event: &responses::ViewBlockEvent, event_sequence: &i32) -> PersistResult {
+  let name = event.name.as_str();
+  if name != "Claimed" {
+    return Ok(())
+  }
+
+  let epoch_number = event.params.get("epoch_number").unwrap().as_str().expect("Malformed response!");
+  let address = event.params.pointer("/data/0/params/0").unwrap().as_str().expect("Malformed response!");
+  // let amount = event.params.pointer("/data/0/params/1").unwrap().as_str().expect("Malformed response!");
+
+  let new_claim = models::NewClaim {
+    transaction_hash: &tx.hash,
+    event_sequence: &event_sequence,
+    block_height: &tx.block_height,
+    block_timestamp: &chrono::NaiveDateTime::from_timestamp(tx.timestamp / 1000, (tx.timestamp % 1000).try_into().unwrap()),
+    initiator_address: address,
+    distributor_address: &event.address,
+    epoch_number: &epoch_number.parse::<i32>().expect("Malformed response"),
+  };
+
+  println!("Inserting: {:?}", new_claim);
+  db::insert_claim(new_claim, &conn)
 }


### PR DESCRIPTION
- Sync claim data and expose a claim API
- Restructured config to avoid having to recompile on reward ratio change
- Support multiple reward distributors
    - Expose full distribution info via `/distribution/info`
    - Each distribution must be generated via `/epoch/generate/{distributionID}` where `distributionID` is the order returned in  `/distribution/info`
    - Renamed `/distribution/current/{address}` to `/distribution/estimated_amounts/{address}` and changed response format to `distributor_address: { pool_token_address: amount } }`.
    - Distribution data endpoint `/distribution/data` updated to also require a `distributor_address`.
- Reworked distribution data endpoint for users to one that only returns unclaimed distributions.