### PR TITLE
Allow swaps to be filtered by multiple comma separated pools

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -25,7 +25,10 @@ pub fn get_swaps(
   let mut query = swaps.into_boxed::<Pg>();
 
   if let Some(pool) = pool {
-    query = query.filter(token_address.eq(pool));
+    let pools = pool.split(",");
+    for p in pools {
+      query = query.or_filter(token_address.eq(p));
+    }
   }
 
   if let Some(address) = address {


### PR DESCRIPTION
This PR allows for swaps to be filtered by multiple pools through comma separation:
`/swaps?pools?=addr1,addr2`